### PR TITLE
Move arrow to Suggests to appease CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,10 +26,10 @@ Encoding: UTF-8
 ByteCompile: true
 Depends: R (>= 4.0)
 Imports:
-    arrow (>= 8.0.0),
     dplyr,
     duckdbfs
 Suggests:
+    arrow (>= 8.0.0),
     spelling,
     dbplyr,
     testthat (>= 3.0.0),
@@ -44,3 +44,4 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Config/testthat/edition: 3
 VignetteBuilder: knitr
+Additional_repositories: https://p3m.dev/cran/2024-02-02/

--- a/R/arrow.R
+++ b/R/arrow.R
@@ -1,0 +1,37 @@
+check_arrow_installed <- function(){
+  if (!requireNamespace("arrow", quietly = TRUE)) {
+    msg <- paste(
+      "The 'arrow' package is required but is not available. Install it with:",
+      'install.packages("arrow", repos = c("https://p3m.dev/cran/2024-02-02", getOption("repos")))',
+      sep = "\n"
+    )
+    stop(msg, call. = FALSE)
+  }
+}
+
+select_backend <- function(choice){
+  backends <- c("arrow", "duckdb")
+  if (identical(choice, backends)) {
+    # User did not specify, this is the default case
+    if (requireNamespace("arrow", quietly = TRUE)) {
+      # arrow is the default option
+      return("arrow")
+    } else {
+      # Sadly, it's not available, so warn and use duckdb
+      msg <- paste(
+        "The 'arrow' is not available. Using 'duckdb' instead. To use arrow, install it with:",
+        'install.packages("arrow", repos = c("https://p3m.dev/cran/2024-02-02", getOption("repos")))',
+        sep = "\n"
+      )
+      warning(msg, call. = FALSE)
+      return("duckdb")
+    }
+  } else if (identical(choice, "arrow")) {
+    # User has explicitly chosen arrow, so error if arrow isn't available
+    check_arrow_installed()
+    return("arrow")
+  } else {
+    # Usual match.args handling
+    return(match.arg(choice, backends))
+  }
+}

--- a/R/gbif_local.R
+++ b/R/gbif_local.R
@@ -22,7 +22,7 @@ gbif_local <- function(dir = gbif_parquet_dir(version = gbif_version(local=TRUE)
                        backend = c("arrow", "duckdb"),
                        safe = TRUE){
   
-  backend <- match.arg(backend)
+  backend <- select_backend(backend)
   gbif <- switch(backend,
          duckdb = duckdb_local(dir),
          arrow = arrow::open_dataset(dir)

--- a/R/gbif_remote.R
+++ b/R/gbif_remote.R
@@ -21,8 +21,8 @@
 #' this will unset any set environmental variables for the duration of the R session.
 #' This behavior can also be turned off globally by setting the option
 #' `gbif_unset_aws` to FALSE (e.g. to use an alternative network endpoint)
-#' @param endpoint_override optional parameter to [arrow::s3_bucket()]
-#' @param ... additional parameters passed to the [arrow::s3_bucket()]
+#' @param endpoint_override optional parameter to `arrow::s3_bucket()`
+#' @param ... additional parameters passed to the `arrow::s3_bucket()`
 #' @return a remote tibble `tbl_sql` class object.
 #' @details 
 #' A summary of this GBIF data, along with column meanings can be found at 
@@ -42,7 +42,7 @@ gbif_remote <-
              endpoint_override = Sys.getenv("AWS_S3_ENDPOINT", "s3.amazonaws.com"),
              backend = c("arrow", "duckdb"),
              ...) {
-      backend <- match.arg(backend)
+      backend <- select_backend(backend)
       gbif = switch(backend,
              arrow = gbif_remote_arrow(version, bucket, unset_aws,
                                        endpoint_override, ...),
@@ -74,9 +74,7 @@ gbif_remote_arrow <-
            unset_aws = getOption("gbif_unset_aws", TRUE),
            endpoint_override = Sys.getenv("AWS_S3_ENDPOINT", "s3.amazonaws.com"),
            ...) {
-    if (!requireNamespace("arrow", quietly = TRUE)) {
-      stop("please install arrow first")
-    }
+    check_arrow_installed()
     if (unset_aws) { unset_aws_env() }
     server <- arrow::s3_bucket(bucket, 
                                endpoint_override = endpoint_override, 

--- a/R/gbif_version.R
+++ b/R/gbif_version.R
@@ -5,7 +5,7 @@
 #' @param dir local directory ([gbif_dir()])
 #' @param bucket Which remote bucket (region) should be checked
 #' @param all show all versions? (logical, default `FALSE`)
-#' @param ... additional arguments to [arrow::s3_bucket]
+#' @param ... additional arguments to `arrow::s3_bucket`
 #' @export
 #' @details A default version can be set using option `gbif_default_version`
 #' @return latest available gbif version, string
@@ -61,7 +61,8 @@ latest_version <- function(versions) {
 remote_versions <- function(bucket = gbif_default_bucket(), 
                             endpoint_override = Sys.getenv("AWS_S3_ENDPOINT"),
                             ...) {
-  
+
+  check_arrow_installed()
   if (getOption("gbif_unset_aws", TRUE)) unset_aws_env()
   s3 <- arrow::s3_bucket(bucket, endpoint_override=endpoint_override, ...)
   versions <- basename(s3$ls("occurrence"))

--- a/man/gbif_remote.Rd
+++ b/man/gbif_remote.Rd
@@ -30,11 +30,11 @@ this will unset any set environmental variables for the duration of the R sessio
 This behavior can also be turned off globally by setting the option
 \code{gbif_unset_aws} to FALSE (e.g. to use an alternative network endpoint)}
 
-\item{endpoint_override}{optional parameter to \code{\link[arrow:s3_bucket]{arrow::s3_bucket()}}}
+\item{endpoint_override}{optional parameter to \code{arrow::s3_bucket()}}
 
 \item{backend}{duckdb or arrow}
 
-\item{...}{additional parameters passed to the \code{\link[arrow:s3_bucket]{arrow::s3_bucket()}}}
+\item{...}{additional parameters passed to the \code{arrow::s3_bucket()}}
 }
 \value{
 a remote tibble \code{tbl_sql} class object.

--- a/man/gbif_version.Rd
+++ b/man/gbif_version.Rd
@@ -21,7 +21,7 @@ gbif_version(
 
 \item{all}{show all versions? (logical, default \code{FALSE})}
 
-\item{...}{additional arguments to \link[arrow:s3_bucket]{arrow::s3_bucket}}
+\item{...}{additional arguments to \code{arrow::s3_bucket}}
 }
 \value{
 latest available gbif version, string

--- a/tests/testthat/test_gbifdb.R
+++ b/tests/testthat/test_gbifdb.R
@@ -11,7 +11,7 @@ test_that("gbif_example_data()", {
 
 test_that("gbif_local()", {
   
-  skip_on_os("solaris")
+  skip_if_not_installed("arrow")
   path <- gbif_example_data()
   gbif <- gbif_local(path, backend = "arrow")
   df <- head(gbif) |> dplyr::collect()
@@ -29,6 +29,7 @@ test_that("gbif_remote()", {
   
   skip_on_cran()
   skip_if_offline()
+  skip_if_not_installed("arrow")
 
   info <- arrow::arrow_info()
   has_s3 <- info$capabilities[["s3"]]


### PR DESCRIPTION
Related to https://github.com/apache/arrow/issues/39806. Since it's not clear that we'll be able to resolve everything with CRAN before February 9, this PR moves arrow from Imports to Suggests. This will prevent your checks failing on CRAN due to arrow's potential archival, but if we don’t get removed, or when we do get back on CRAN, you can revert this.